### PR TITLE
Fix build for latest rust

### DIFF
--- a/Kernel/Makefile
+++ b/Kernel/Makefile
@@ -57,18 +57,20 @@ ifeq ($(ARCH),amd64)
 	@$(OBJCOPY) $@.elf64 -F elf32-i386 $@
 endif
 
-../libcore/lib.rs: ../rustc-nightly-src.tar.gz
-	tar -xmf ../rustc-nightly-src.tar.gz -C ../ rustc-nightly-src/src/libcore rustc-nightly-src/src/stdsimd --transform 's~^rustc-nightly-src/src/~~'
-../libcompiler_builtins/src/lib.rs: ../rustc-nightly-src.tar.gz
-	tar -xmf ../rustc-nightly-src.tar.gz -C ../ rustc-nightly-src/vendor/compiler_builtins --transform 's~^rustc-nightly-src/vendor/~lib~'
+../library/core/src/lib.rs: ../rustc-nightly-src.tar.gz
+	tar -xmf ../rustc-nightly-src.tar.gz -C ../ rustc-nightly-src/library/core/src rustc-nightly-src/library/stdarch/crates/core_arch/src --transform 's~^rustc-nightly-src/~~'
 
-# Compile libcore from ../libcore/
-$(OBJDIR)libcore.rlib: ../libcore/lib.rs Makefile $(TARGETSPEC)
+../vendor/compiler_builtins/src/lib.rs: ../rustc-nightly-src.tar.gz
+	tar -xmf ../rustc-nightly-src.tar.gz -C ../ rustc-nightly-src/vendor/compiler_builtins --transform 's~^rustc-nightly-src/~~'
+
+# Compile libcore
+$(OBJDIR)libcore.rlib: ../library/core/src/lib.rs Makefile $(TARGETSPEC)
 	@mkdir -p $(dir $@)
 	$(RUSTC) $(RUSTFLAGS) --out-dir=$(OBJDIR) --crate-type=lib --crate-name=core --emit=link,dep-info --edition 2018 $<
-$(OBJDIR)libcompiler_builtins.rlib: ../libcompiler_builtins/src/lib.rs Makefile $(TARGETSPEC) $(OBJDIR)libcore.rlib
+
+$(OBJDIR)libcompiler_builtins.rlib: ../vendor/compiler_builtins/src/lib.rs Makefile $(TARGETSPEC) $(OBJDIR)libcore.rlib
 	@mkdir -p $(dir $@)
-	$(RUSTC) $(RUSTFLAGS) --out-dir=$(OBJDIR) --cfg feature=\"compiler-builtins\" --emit=link,dep-info --extern core=$(LIBCORE) $< --cfg stage0
+	$(RUSTC) $(RUSTFLAGS) --out-dir=$(OBJDIR) --crate-type=lib --crate-name=compiler_builtins --cfg feature=\"compiler-builtins\" --emit=link,dep-info --extern core=$(LIBCORE) $< --cfg stage0
 
 # Compile rust kernel object
 $(OBJDIR)kernel.o: main.rs $(LIBCORE) $(OBJDIR)libcompiler_builtins.rlib Makefile $(TARGETSPEC)

--- a/Kernel/arch/x86_common/io.rs
+++ b/Kernel/arch/x86_common/io.rs
@@ -16,42 +16,42 @@
 /// Write a byte to the specified port
 pub unsafe fn outb(port: u16, val: u8)
 {
-	asm!("outb $0, $1" : : "{al}"(val), "{dx}N"(port));
+	llvm_asm!("outb $0, $1" : : "{al}"(val), "{dx}N"(port));
 }
 
 /// Read a single byte from the specified port
 pub unsafe fn inb(port: u16) -> u8
 {
 	let ret : u8;
-	asm!("inb $1, $0" : "={al}"(ret) : "{dx}N"(port));
+	llvm_asm!("inb $1, $0" : "={al}"(ret) : "{dx}N"(port));
 	return ret;
 }
 
 /// Write a word (16-bits) to the specified port
 pub unsafe fn outw(port: u16, val: u16)
 {
-	asm!("outw $0, $1" : : "{ax}"(val), "{dx}N"(port));
+	llvm_asm!("outw $0, $1" : : "{ax}"(val), "{dx}N"(port));
 }
 
 /// Read a word (16-bits) from the specified port
 pub unsafe fn inw(port: u16) -> u16
 {
 	let ret : u16;
-	asm!("inw $1, $0" : "={ax}"(ret) : "{dx}N"(port));
+	llvm_asm!("inw $1, $0" : "={ax}"(ret) : "{dx}N"(port));
 	return ret;
 }
 
 /// Write a long/double-word (32-bits) to the specified port
 pub unsafe fn outl(port: u16, val: u32)
 {
-	asm!("outl $0, $1" : : "{eax}"(val), "{dx}N"(port));
+	llvm_asm!("outl $0, $1" : : "{eax}"(val), "{dx}N"(port));
 }
 
 /// Read a long/double-word (32-bits) from the specified port
 pub unsafe fn inl(port: u16) -> u32
 {
 	let ret : u32;
-	asm!("inl $1, $0" : "={eax}"(ret) : "{dx}N"(port));
+	llvm_asm!("inl $1, $0" : "={eax}"(ret) : "{dx}N"(port));
 	return ret;
 }
 

--- a/Kernel/main.rs
+++ b/Kernel/main.rs
@@ -9,7 +9,7 @@
  * its use, and the author takes no liability.
  */
 #![feature(panic_info_message)]	//< Panic handling
-#![feature(asm)]	//< As a kernel, we need inline assembly
+#![feature(llvm_asm)]	//< As a kernel, we need inline assembly
 #![no_std]	//< Kernels can't use std
 #![crate_name="kernel"]
 


### PR DESCRIPTION
Updates the makefile to the new directory structure of rustc-nightly, in order to build libcore and compiler_builtins correctly.
Also the `asm!`-macro was updated, I tried to adapt `Kernel/arch/x86_common/io.rs` to the new `asm!`-syntax but could not get it right, so I simply changed it to `llvm_asm!()`